### PR TITLE
LINEBOT からメッセージを投稿時にidとlastDisplayedAtを追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -178,8 +178,10 @@ def post_cheer_form_confirm():
     tag = event['tag'][:- len("の皆様へ")]
     message = event['message']
     # Firebase に保存
-    message_collection.document().set(
-        Message(tag, message).to_dict())
+    msg = Message(tag, message)
+    message_collection.document(msg.id).set(
+        msg.to_dict()
+    )
 
     reply_message = f'応援メッセージを送信しました。\n\n{tag}の皆様へ\n{message}'
 

--- a/src/models/message.py
+++ b/src/models/message.py
@@ -1,5 +1,7 @@
 import datetime
 import json
+import random
+import string
 
 from firebase_admin import firestore
 from settings import db
@@ -45,12 +47,17 @@ def get_messages_by_tag(tag, num_of_massage):
     return return_json
 
 
+# n桁のランダム文字列を返す: 7we4CMGjTj
+def random_id(n):
+    return ''.join(random.choices(string.ascii_letters + string.digits, k=n))
+
+
 class Message(object):
     def __init__(
             self,
-            id,
             sendTo,
             context,
+            id=random_id(10),  # メッセージ識別ID
             likes=0,
             created_at=firestore.firestore.SERVER_TIMESTAMP,
             last_displayed_at=firestore.firestore.SERVER_TIMESTAMP
@@ -75,7 +82,7 @@ class Message(object):
 
     def to_dict(self):
         return {
-            "if": self.id,
+            "id": self.id,
             "sendTo": self.sendTo,
             "context": self.context,
             "likes": self.likes,


### PR DESCRIPTION
## 概要
Fix #24

LINEBOT からメッセージを投稿時にidとlastDisplayedAtを追加した．
また，Firebase上にドキュメントを作成する時に，ドキュメントIDを上記idと同じにした

## 詳細（主に技術的変更点）

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）

## 保留した項目・TODOリスト

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）
